### PR TITLE
Update to newest version of `legend-test-data`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [legend_testdata]
-git-tree-sha1 = "f0aa7fef9f9e036c5153061b83c23929bbc1fd67"
+git-tree-sha1 = "fa62c8135044cd5672a15bd775d7c312c26c46a3"
 
     [[legend_testdata.download]]
-    sha256 = "12343277fa8d6f595f04cf77d22ea95bac6de2b5315def1a0a3663e3529fff58"
-    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/7df474059cb6cf1d7c7ff836ddfb7e8d3373abb0"
+    sha256 = "3c5176d0aa2c00f6510a7534a51bbae2be3c1c66e690b4fe695dad8a7055df6b"
+    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/112999395958e2ac03d0c9243c8b6ee877d4e058"

--- a/Project.toml
+++ b/Project.toml
@@ -4,3 +4,6 @@ version = "0.2.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[extras]
+PropDicts = "4dc08600-4268-439e-8673-d706fafbb426"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendTestData"
 uuid = "33d6da08-6349-5f7c-b5a4-6ff4d8795aaf"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/LegendTestData.jl
+++ b/src/LegendTestData.jl
@@ -22,7 +22,7 @@ managed via [DataDeps.jl](https://github.com/oxinabox/DataDeps.jl).
 Set `ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"` to avoid interactive prompt
 asking for download permission.
 """
-legend_test_data_path() = joinpath(artifact"legend_testdata", "legend-exp-legend-testdata-7df4740")
+legend_test_data_path() = joinpath(artifact"legend_testdata", "legend-exp-legend-testdata-1129993")
 export legend_test_data_path
 
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,6 @@
 [deps]
+PropDicts = "4dc08600-4268-439e-8673-d706fafbb426"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+PropDicts = "0.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,21 @@
 # This file is a part of LegendTestData.jl, licensed under the MIT License (MIT).
 
 using LegendTestData
+using PropDicts
 using Test
 
 @testset "Package LegendTestData" begin
 
-@info legend_test_data_path()
-@test isdir(joinpath(legend_test_data_path(), "data"))
+    @info legend_test_data_path()
+    @test isdir(joinpath(legend_test_data_path(), "data"))
+
+    @testset "Inverted coax metadata" begin
+        invcoax_metadata = joinpath(legend_test_data_path(), "data", "ldsim", "invcoax-metadata.json")
+        @test isfile(invcoax_metadata)
+        invcoax = readprops(invcoax_metadata)
+        @test haskey(invcoax.geometry.borehole, :depth_in_mm)
+        @test invcoax.geometry.borehole.depth_in_mm == 55
+        @test !haskey(invcoax.geometry.borehole, :gap_in_mm)
+    end
 
 end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test
 
 @testset "Package LegendTestData" begin
 
+@info legend_test_data_path()
 @test isdir(joinpath(legend_test_data_path(), "data"))
 
 end # testset


### PR DESCRIPTION
Fixes #3

This is the code I used to update the `Artifacts.toml`:
```julia
using ArtifactUtils, Artifacts
import Pkg

pkg_dir = "<insert_directory_of_LegendTestData.jl>"
cd(pkg_dir)
Pkg.activate(pkg_dir)

commit = "112999395958e2ac03d0c9243c8b6ee877d4e058" # or whatever commit message is the newest
artifact_id = add_artifact!(
    "Artifacts.toml",
    "legend_testdata",
    "https://api.github.com/repos/legend-exp/legend-testdata/tarball/" * commit,
    force = true
)

Pkg.ensure_artifact_installed("legend_testdata", "Artifacts.toml")
```
