### PR TITLE
Update to newest version of `legend-test-data`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [legend_testdata]
-git-tree-sha1 = "fa62c8135044cd5672a15bd775d7c312c26c46a3"
+git-tree-sha1 = "1507a7ef610d2558536241dbb7a7b402a1882269"
 
     [[legend_testdata.download]]
-    sha256 = "3c5176d0aa2c00f6510a7534a51bbae2be3c1c66e690b4fe695dad8a7055df6b"
-    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/112999395958e2ac03d0c9243c8b6ee877d4e058"
+    sha256 = "154e9b4b9c8c862a45102e3a484cb62254ab477aea0aaba4f1283c6873e818a8"
+    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/32262e44d0a32849a7d2d6d16b406f93e4e9d2d9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendTestData"
 uuid = "33d6da08-6349-5f7c-b5a4-6ff4d8795aaf"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/LegendTestData.jl
+++ b/src/LegendTestData.jl
@@ -22,7 +22,7 @@ managed via [DataDeps.jl](https://github.com/oxinabox/DataDeps.jl).
 Set `ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"` to avoid interactive prompt
 asking for download permission.
 """
-legend_test_data_path() = joinpath(artifact"legend_testdata", "legend-exp-legend-testdata-1129993")
+legend_test_data_path() = joinpath(artifact"legend_testdata", "legend-exp-legend-testdata-32262e4")
 export legend_test_data_path
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,4 +18,17 @@ using Test
         @test !haskey(invcoax.geometry.borehole, :gap_in_mm)
     end
 
+    @testset "Crystal metadata" begin
+        crystal_metadata_dir = joinpath(legend_test_data_path(), "data", "legend", "metadata", "hardware", "detectors", "germanium", "crystals")
+        @test isdir(crystal_metadata_dir)
+        crystal_metadata_file = joinpath(crystal_metadata_dir, "V99000.json")
+        @test isfile(crystal_metadata_file)
+        crystal_metadata = readprops(crystal_metadata_file)
+        @test haskey(crystal_metadata, :impurity_measurements)
+        @test haskey(crystal_metadata.impurity_measurements, :value_in_1e9e_cm3)
+        @test haskey(crystal_metadata.impurity_measurements, :distance_from_seed_end_mm)
+        @test crystal_metadata.impurity_measurements.value_in_1e9e_cm3 == [8, 9, 10, 10, 11]
+        @test crystal_metadata.impurity_measurements.distance_from_seed_end_mm == [0, 14, 30, 50, 80]
+    end
+
 end # testset


### PR DESCRIPTION
This PR updates LegendTestData.jl to link to the [newest commit](https://github.com/legend-exp/legend-testdata/commit/32262e44d0a32849a7d2d6d16b406f93e4e9d2d9) of `legend-testdata` that includes the crystal metadata database.

@oschulz please merge and release this such that it can be used for the tests in LegendGeSim.jl