### PR TITLE
 Update to newest version of `legend-test-data`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [legend_testdata]
-git-tree-sha1 = "f6ee83236379175149ce1adac4af2c575452ad93"
+git-tree-sha1 = "9be4f8fe603d54d6f787de53b2ad660bb3ed3bdc"
 
     [[legend_testdata.download]]
-    sha256 = "c2878d9913ae2c820773a1cc0edb3cb23fa4676899c3c1d78faa22fe9cf87292"
-    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/82ad6c28de3b7a0cc735c6827dd83a242561afd8"
+    sha256 = "ea5c81984a1b7670900512dfb6686487114b2927b8789e4b66a6f7a5462fdb35"
+    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/2553a28262a9447a2f61b1ad428b1b5a44546cd7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendTestData"
 uuid = "33d6da08-6349-5f7c-b5a4-6ff4d8795aaf"
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/LegendTestData.jl
+++ b/src/LegendTestData.jl
@@ -22,7 +22,7 @@ managed via [DataDeps.jl](https://github.com/oxinabox/DataDeps.jl).
 Set `ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"` to avoid interactive prompt
 asking for download permission.
 """
-legend_test_data_path() = joinpath(artifact"legend_testdata", "legend-exp-legend-testdata-82ad6c2")
+legend_test_data_path() = joinpath(artifact"legend_testdata", "legend-exp-legend-testdata-2553a28")
 export legend_test_data_path
 
 


### PR DESCRIPTION
This PR updates LegendTestData.jl to link to the [newest commit](https://github.com/legend-exp/legend-testdata/commit/2553a28262a9447a2f61b1ad428b1b5a44546cd7) of legend-testdata that fixes the groove values for the test detector `B99000A`.