### PR TITLE
Update LEGEND test data to new format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1.10'
           - '1'
           - 'pre'

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [legend_testdata]
-git-tree-sha1 = "11b2a7ab47d6f84b449b8f16112d0f3489ec697d"
+git-tree-sha1 = "2d0e064cb31aee3ccc15daa535f4738d084b898c"
 
     [[legend_testdata.download]]
-    sha256 = "da41b0d66808cd49a40fc1e19d4ba1c76e326aed0308b39c3085b12d5c168477"
-    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/cd70a8d731e3cd1453e224eb567f257c34fe8b5f"
+    sha256 = "b5b52e45e312cab6db203697c39a10056e3b027e296846ea6684d0bba928ed7a"
+    url = "https://api.github.com/repos/legend-exp/legend-testdata/tarball/efbe443a0db4e6f75536ccb2f91b28b692870faa"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendTestData"
 uuid = "33d6da08-6349-5f7c-b5a4-6ff4d8795aaf"
-version = "0.2.10"
+version = "0.3.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/LegendTestData.jl
+++ b/src/LegendTestData.jl
@@ -10,7 +10,7 @@ module LegendTestData
 using Artifacts
 
 
-const _legend_testdata_commit="cd70a8d"
+const _legend_testdata_commit="efbe443"
 
 """
     legend_test_data_path()::AbstractString
@@ -36,8 +36,21 @@ configuration
 """
 function activate_legend_test_data_config()
     testdata_dir = joinpath(legend_test_data_path(), "data", "legend")
-    ENV["LEGEND_DATA_CONFIG"] = joinpath(testdata_dir, "config.json")
+    ENV["LEGEND_DATA_CONFIG"] = joinpath(testdata_dir, "dataflow-config.yaml")
 end
 export activate_legend_test_data_config
+
+
+"""
+    activate_old_legend_test_data_config()
+
+Set environment variable `"LEGEND_DATA_CONFIG"` to the LEGEND test data
+configuration in the last state before refactoring to YAML
+"""
+function activate_old_legend_test_data_config()
+    testdata_dir = joinpath(legend_test_data_path(), "data", "legend_old")
+    ENV["LEGEND_DATA_CONFIG"] = joinpath(testdata_dir, "config.json")
+end
+export activate_old_legend_test_data_config
 
 end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,3 +3,6 @@ PropDicts = "4dc08600-4268-439e-8673-d706fafbb426"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+PropDicts = "0.2.8"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ include("test_aqua.jl")
     @testset "Crystal metadata" begin
         crystal_metadata_dir = joinpath(legend_test_data_path(), "data", "legend", "metadata", "hardware", "detectors", "germanium", "crystals")
         @test isdir(crystal_metadata_dir)
-        crystal_metadata_file = joinpath(crystal_metadata_dir, "V99000.json")
+        crystal_metadata_file = joinpath(crystal_metadata_dir, "V99000.yaml")
         @test isfile(crystal_metadata_file)
         crystal_metadata = readprops(crystal_metadata_file)
         @test haskey(crystal_metadata, :impurity_measurements)
@@ -38,8 +38,14 @@ include("test_aqua.jl")
 
     @testset "Test data config" begin
         ENV["LEGEND_DATA_CONFIG"] = ""
+
+        activate_old_legend_test_data_config()
+        @test isfile(ENV["LEGEND_DATA_CONFIG"])
+        @test endswith(ENV["LEGEND_DATA_CONFIG"], ".json")
+
         activate_legend_test_data_config()
         @test isfile(ENV["LEGEND_DATA_CONFIG"])
+        @test endswith(ENV["LEGEND_DATA_CONFIG"], ".yaml")
     end
 end # testset
 


### PR DESCRIPTION
Once https://github.com/legend-exp/legend-testdata/pull/28 is merged, we can update to the final commit SHA, but the metadata files seem to be read in correctly and the tests (after adjust for some YAML tweaks) seem to pass.

As the new YAML format is breaking, I would propose bumping the minor version after merging this --> `0.3.0`